### PR TITLE
chore(templates): update wasmbus and interface deps in templates

### DIFF
--- a/hello-world/rust/Cargo.toml
+++ b/hello-world/rust/Cargo.toml
@@ -11,8 +11,8 @@ name = "{{to_snake_case project-name}}"
 [dependencies]
 futures = "0.3"
 
-wasmbus-rpc = "0.11"
-wasmcloud-interface-httpserver = "0.8.2"
+wasmbus-rpc = "0.14"
+wasmcloud-interface-httpserver = "0.11"
 
 [profile.release]
 # Optimize for small code size

--- a/kvcounter/rust/Cargo.toml
+++ b/kvcounter/rust/Cargo.toml
@@ -15,9 +15,9 @@ serde_bytes = "0.11"
 serde_json ="1.0"
 serde = {version = "1.0", features = ["derive"]}
 
-wasmbus-rpc = "0.11"
-wasmcloud-interface-keyvalue = "0.9"
-wasmcloud-interface-httpserver = "0.8"
+wasmbus-rpc = "0.14"
+wasmcloud-interface-keyvalue = "0.11"
+wasmcloud-interface-httpserver = "0.11"
 
 [profile.release]
 # Optimize for small code size

--- a/multi-channel-chat/api-gateway/Cargo.toml
+++ b/multi-channel-chat/api-gateway/Cargo.toml
@@ -13,16 +13,16 @@ async-trait = "0.1"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.86"
-wasmbus-rpc = "0.10"
-wasmcloud-interface-keyvalue = "0.8.0"
-wasmcloud-interface-logging = "0.7.1"
+wasmbus-rpc = "0.14"
+wasmcloud-interface-keyvalue = "0.11"
+wasmcloud-interface-logging = "0.10"
 
 [dev-dependencies]
 base64 = "0.13"
 
 # build-dependencies needed for build.rs
 [build-dependencies]
-weld-codegen = "0.5.0"
+weld-codegen = "0.7.0"
 
 [profile.release]
 # Optimize for small code size

--- a/multi-channel-chat/chatlog/Cargo.toml
+++ b/multi-channel-chat/chatlog/Cargo.toml
@@ -13,16 +13,16 @@ async-trait = "0.1"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.86"
-wasmbus-rpc = "0.10"
-wasmcloud-interface-keyvalue = "0.8.0"
-wasmcloud-interface-logging = "0.7.1"
+wasmbus-rpc = "0.14"
+wasmcloud-interface-keyvalue = "0.11"
+wasmcloud-interface-logging = "0.10"
 
 [dev-dependencies]
 base64 = "0.13"
 
 # build-dependencies needed for build.rs
 [build-dependencies]
-weld-codegen = "0.5.0"
+weld-codegen = "0.7.0"
 
 [profile.release]
 # Optimize for small code size

--- a/multi-channel-chat/http-channel/Cargo.toml
+++ b/multi-channel-chat/http-channel/Cargo.toml
@@ -13,10 +13,10 @@ async-trait = "0.1"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.86"
-wasmbus-rpc = "0.10"
-wasmcloud-interface-httpserver = "0.7.0"
-wasmcloud-interface-numbergen = "0.7.0"
-wasmcloud-interface-logging = "0.7.1"
+wasmbus-rpc = "0.14"
+wasmcloud-interface-httpserver = "0.11"
+wasmcloud-interface-numbergen = "0.10"
+wasmcloud-interface-logging = "0.10"
 
 
 [dev-dependencies]
@@ -24,7 +24,7 @@ base64 = "0.13"
 
 # build-dependencies needed for build.rs
 [build-dependencies]
-weld-codegen = "0.5.0"
+weld-codegen = "0.7.0"
 
 [profile.release]
 # Optimize for small code size

--- a/multi-channel-chat/nats-channel/Cargo.toml
+++ b/multi-channel-chat/nats-channel/Cargo.toml
@@ -13,9 +13,9 @@ async-trait = "0.1"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.86"
-wasmbus-rpc = "0.10"
-wasmcloud-interface-messaging = "0.7.0"
-wasmcloud-interface-numbergen = "0.7.0"
+wasmbus-rpc = "0.14"
+wasmcloud-interface-messaging = "0.10"
+wasmcloud-interface-numbergen = "0.10"
 
 
 [dev-dependencies]
@@ -23,7 +23,7 @@ base64 = "0.13"
 
 # build-dependencies needed for build.rs
 [build-dependencies]
-weld-codegen = "0.5.0"
+weld-codegen = "0.7.0"
 
 [profile.release]
 # Optimize for small code size

--- a/xkcdgenerator/Cargo.lock
+++ b/xkcdgenerator/Cargo.lock
@@ -114,26 +114,25 @@ checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
 
 [[package]]
 name = "async-nats"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1174495e436c928905018f10a36160f7a8a6786450f50f4ce7fba05d1539704c"
+checksum = "94e3e851ddf3b62be8a8085e1e453968df9cdbf990a37bbb589b5b4f587c68d7"
 dependencies = [
- "async-nats-tokio-rustls-deps",
- "base64 0.13.0",
- "base64-url",
+ "base64 0.21.1",
  "bytes",
  "futures",
  "http",
  "itoa",
  "memchr",
  "nkeys",
- "nuid",
+ "nuid 0.3.2",
  "once_cell",
  "rand",
  "regex",
  "ring",
  "rustls-native-certs",
  "rustls-pemfile",
+ "rustls-webpki 0.101.1",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -142,19 +141,9 @@ dependencies = [
  "time",
  "tokio",
  "tokio-retry",
+ "tokio-rustls 0.24.1",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "async-nats-tokio-rustls-deps"
-version = "0.24.0-ALPHA.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdefe54cd7867d937c0a507d2a3a830af410044282cd3e4002b5b7860e1892e"
-dependencies = [
- "rustls 0.21.1",
- "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -273,15 +262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
 
 [[package]]
-name = "base64-url"
-version = "1.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a99c239d0c7e77c85dddfa9cebce48704b3c49550fcd3b84dd637e4484899f"
-dependencies = [
- "base64 0.13.0",
-]
-
-[[package]]
 name = "base64ct"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +299,12 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
+
+[[package]]
+name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
@@ -328,6 +314,9 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -446,7 +435,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
@@ -558,12 +547,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -890,7 +879,7 @@ dependencies = [
  "hyper",
  "rustls 0.20.6",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -972,6 +961,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "lexical-sort"
@@ -1085,11 +1080,11 @@ dependencies = [
 
 [[package]]
 name = "nkeys"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e66a7cd1358277b2a6f77078e70aea7315ff2f20db969cc61153103ec162594"
+checksum = "c2d151f6ece2f3d1077f6c779268de2516653d8344ddde65addd785cce764fe5"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "data-encoding",
  "ed25519-dalek",
  "getrandom",
@@ -1105,6 +1100,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20c1bb65186718d348306bf1afdeb20d9ab45b2ab80fb793c0fdcf59ffbb4f38"
 dependencies = [
  "lazy_static",
+ "rand",
+]
+
+[[package]]
+name = "nuid"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b61b1710432e483e6a67b20b6c60c6afe0e2fad67aabba3bdb912f3f70ff6ae"
+dependencies = [
+ "once_cell",
  "rand",
 ]
 
@@ -1162,12 +1167,6 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "parity-wasm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "parking_lot"
@@ -1499,7 +1498,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1530,7 +1529,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "num-traits",
  "paste",
 ]
@@ -1541,7 +1540,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25786b0d276110195fa3d6f3f31299900cf71dfbd6c28450f3f58a0e7f7a347e"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "rmp",
  "serde",
 ]
@@ -1592,7 +1591,7 @@ checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.100.1",
  "sct",
 ]
 
@@ -1622,6 +1621,16 @@ name = "rustls-webpki"
 version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
 dependencies = [
  "ring",
  "untrusted",
@@ -2073,6 +2082,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.1",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "wascap"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d1cfad67501627ac9344cbd89be80d2d5ebc98ef3b86862041cb26a280081f"
+checksum = "c38c03de923f80027cb62281f520bd97245a38eeb85a53f435a110509d044551"
 dependencies = [
  "base64 0.13.0",
  "data-encoding",
@@ -2341,12 +2360,14 @@ dependencies = [
  "lazy_static",
  "log",
  "nkeys",
- "nuid",
- "parity-wasm",
+ "nuid 0.4.1",
  "ring",
  "serde",
  "serde_derive",
  "serde_json",
+ "wasm-encoder",
+ "wasm-gen",
+ "wasmparser",
 ]
 
 [[package]]
@@ -2422,6 +2443,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-gen"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b854b1461005a7b3365742310f7faa3cac3add809d66928c64a40c7e9e842ebb"
+dependencies = [
+ "byteorder 0.5.3",
+ "leb128",
+]
+
+[[package]]
 name = "wasmbus-macros"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,9 +2475,9 @@ dependencies = [
 
 [[package]]
 name = "wasmbus-rpc"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba72e61b8361650149b2650b72c583a1d50ac78f75213b74eaec049699c5d93"
+checksum = "2da4e25698e9e15af56e9bb510d233495c4ec9c6bbbf13d046205190dd4ab935"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -2472,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-interface-httpclient"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f2b52fd05280bc83a2411bd42391cabd4ab20a63850f4a3d64055fd71da985"
+checksum = "9457b98b82ab3c835cb68f619f6ad874d4f003c92a39d3a6749a26da3536499e"
 dependencies = [
  "async-trait",
  "futures",
@@ -2487,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-interface-httpserver"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d96cd17d32dd3d3fb14f05a69ce4ac62c52d13c68903d2dc8cefd2d906bce"
+checksum = "424c4bd21e2494711997a2a9e07aa4d14ff2c4c4db3e08a0f6099345544383c5"
 dependencies = [
  "async-trait",
  "serde",
@@ -2501,9 +2541,9 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-interface-numbergen"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42611f377f9a3ae39d6db7ea9679dd2cd1e8c53793a9f4f19b027ee2d4a4b02f"
+checksum = "5261923d3a3b0eb9a3dfdace613dfaea838434222a3970594648f270e4da0e51"
 dependencies = [
  "async-trait",
  "futures",
@@ -2512,6 +2552,16 @@ dependencies = [
  "serde_json",
  "wasmbus-rpc",
  "weld-codegen",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
+dependencies = [
+ "indexmap",
+ "semver",
 ]
 
 [[package]]

--- a/xkcdgenerator/Cargo.toml
+++ b/xkcdgenerator/Cargo.toml
@@ -12,10 +12,10 @@ name = "xkcdgenerator"
 futures = "0.3"
 serde = "1.0.145"
 serde_json = "1.0.85"
-wasmbus-rpc = "0.13"
-wasmcloud-interface-httpserver = "0.10"
-wasmcloud-interface-numbergen = "0.9"
-wasmcloud-interface-httpclient = "0.9"
+wasmbus-rpc = "0.14"
+wasmcloud-interface-httpserver = "0.11"
+wasmcloud-interface-numbergen = "0.10"
+wasmcloud-interface-httpclient = "0.10"
 
 [profile.release]
 # Optimize for small code size


### PR DESCRIPTION
Updates versions to wasmbus-rpc 0.14 equivalents.